### PR TITLE
Add global exception handler for API

### DIFF
--- a/src/main/java/com/spectrosystems/student_management_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/spectrosystems/student_management_api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.spectrosystems.student_management_api.exception;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.NoSuchElementException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<String> handleNotFound(NoSuchElementException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleGeneric(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body("An unexpected error occurred: " + ex.getMessage());
+    }
+}


### PR DESCRIPTION
Introduces a GlobalExceptionHandler class using @ControllerAdvice to handle NoSuchElementException and generic exceptions, returning appropriate HTTP status codes and messages for improved error handling.